### PR TITLE
Fix Beatmap Length

### DIFF
--- a/src/api/BanchoV2.ts
+++ b/src/api/BanchoV2.ts
@@ -85,7 +85,7 @@ interface BeatmapExtended extends Beatmap {
     cs: number;
     deleted_at?: string;
     drain: number;
-    hit_length: number;
+    total_length: number;
     is_scoreable: boolean;
     last_updated: string;
     mode_int: number;
@@ -209,7 +209,7 @@ class V2Beatmap implements APIBeatmap {
         };
 
         this.bpm = beatmap.bpm;
-        this.length = beatmap.hit_length;
+        this.length = beatmap.total_length;
 
         this.creator = {
             nickname: beatmap.beatmapset.creator,


### PR DESCRIPTION
Real Length of beatmap
(hit_length just show length without breaks,
-intro, -outro, - breaks)

<img width="1161" height="439" alt="image" src="https://github.com/user-attachments/assets/5f16f287-3bfd-47a4-a9cf-388ea660044e" />
<img width="922" height="206" alt="image" src="https://github.com/user-attachments/assets/4ebe9c06-ef69-4abe-804e-c62c2639d846" />
<img width="568" height="112" alt="image" src="https://github.com/user-attachments/assets/2378798c-5e3e-45a0-bd5a-26e647f8233d" />
<img width="568" height="112" alt="image" src="https://github.com/user-attachments/assets/f8b86964-817e-417a-8906-41ed9bc17bef" />
