### PR TITLE
fix(vk): deduplicate message links

### DIFF
--- a/bot/src/platforms/vk/VKMessageContext.ts
+++ b/bot/src/platforms/vk/VKMessageContext.ts
@@ -403,9 +403,7 @@ export class VKMessageContext extends BaseMessageContext {
 
     getLinks(): ITextLinkEntity[] {
         const links: ITextLinkEntity[] = [];
-        for (const attachment of this.messageContext?.getAttachments("link") ?? []) {
-            links.push({ type: "text_link", offset: 0, length: 0, url: attachment.url });
-        }
+        const seenUrls = new Set<string>();
 
         const text = this.plainText ?? "";
         for (const match of text.matchAll(/https?:\/\/[^\s]+/gi)) {
@@ -417,6 +415,15 @@ export class VKMessageContext extends BaseMessageContext {
                 length: url.length,
                 url,
             });
+            seenUrls.add(url);
+        }
+
+        for (const attachment of this.messageContext?.getAttachments("link") ?? []) {
+            if (seenUrls.has(attachment.url)) {
+                continue;
+            }
+            links.push({ type: "text_link", offset: 0, length: 0, url: attachment.url });
+            seenUrls.add(attachment.url);
         }
         return links;
     }

--- a/bot/tests/VKMessageContext.test.ts
+++ b/bot/tests/VKMessageContext.test.ts
@@ -165,6 +165,44 @@ test("VK treats the first forwarded message as a reply fallback", () => {
     });
 });
 
+test("VK prefers text links and deduplicates matching link attachments", () => {
+    const textUrl = "https://osu.ppy.sh/beatmaps/123";
+    const attachmentUrl = "https://osu.ppy.sh/scores/456";
+    const getAttachments = jest.fn((type: string) =>
+        type === "link" ? [{ url: textUrl }, { url: attachmentUrl }] : []
+    );
+    const context = new VKMessageContext(
+        {
+            type: "message",
+            id: 1,
+            senderId: 10,
+            peerId: 10,
+            text: `map ${textUrl}.`,
+            getAttachments,
+        } as never,
+        {} as never,
+        30,
+        40,
+        createTestStorage({ platform: "vk" }),
+        new FluentLocalizer(runtimePaths.locales)
+    );
+
+    expect(context.getLinks()).toEqual([
+        {
+            type: "text_link",
+            offset: 4,
+            length: textUrl.length,
+            url: textUrl,
+        },
+        {
+            type: "text_link",
+            offset: 0,
+            length: 0,
+            url: attachmentUrl,
+        },
+    ]);
+});
+
 test("VK retries buffered photo uploads through the community client for the destination peer", async () => {
     const timeout = new Error("upload timeout");
     timeout.name = "AbortError";


### PR DESCRIPTION

- prefer URLs parsed from VK message text
- ignore matching or repeated link attachments
- preserve distinct attachment-only links as a fallback
